### PR TITLE
Add undefined-only expansions (${VAR-}, ${VAR+})

### DIFF
--- a/expand_test.go
+++ b/expand_test.go
@@ -8,6 +8,14 @@ import (
 
 func TestExpansions(t *testing.T) {
 	lookup := func(key string) (value string, ok bool) {
+		switch key {
+		case "empty":
+			return "", true
+		case "none":
+			return "", false
+		default:
+			return "text", true
+		}
 		return "text", key != "none"
 	}
 
@@ -77,6 +85,16 @@ func TestExpansions(t *testing.T) {
 			"EscapeDelimiterBracedDefined",
 			"$${key:+defined}${key:+defined}",
 			"${key:+defined}defined",
+		},
+		{
+			"ExpandUndefinedOnly",
+			"${none-not a variable}",
+			"not a variable",
+		},
+		{
+			"ExpandDefinedOnly",
+			"${key+x} ${empty+empty var} ${none+y}",
+			"x empty var ",
 		},
 		{
 			"NestedInterpolations",


### PR DESCRIPTION
This adds a few shell-like expansions that weren't previously
supported, specifically expand-if-undefined and expand-if-defined,
mostly to complement the existence of ${VAR:-} and ${VAR:+}, which only
really care if the variable is null.

- Update package doc to explain the added expansions.
- Update other docs to point to the package doc for the expansions list.
- Add ${VAR+} and ${VAR-} expansions as exDefined and exUndefined.
- ${VAR:+} is now exDefinedNotEmpty.
- ${VAR:/} is now exUndefinedTest.